### PR TITLE
chore: gradle 빌드시 로그 안나타나도록 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Build with Gradle
-        run: ./gradlew build --stacktrace --debug
+        run: ./gradlew build
 
       - name: Build docker image
         run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/member-service:latest -f Dockerfile .


### PR DESCRIPTION
- #34 
- 빌드시 로그가 출력되면 보안 문제가 있어 안나타나도록 수정했습니다.