### PR TITLE
chore: gitignore 공백 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,3 @@ out/
 
 ### VS Code ###
 .vscode/
-


### PR DESCRIPTION
- main브랜치와 충돌을 방지하기 위해 gitignore 공백을 제거했습니다.