### PR TITLE
hotfix: 구독 조회 테스트 코드 수정

### DIFF
--- a/src/main/java/com/leeforgiveness/memberservice/sms/presentation/SmsController.java
+++ b/src/main/java/com/leeforgiveness/memberservice/sms/presentation/SmsController.java
@@ -22,7 +22,7 @@ public class SmsController {
 
     private final SmsService smsService;
 
-    @PostMapping("/cerify")
+    @PostMapping("/certify")
     @Operation(summary = "인증메세지 발송", description = "인증메세지 발송")
     public SingleMessageSentResponse sendOne(@RequestBody SmsSendDto smsSendDto) {
         log.info("메세지 발송");

--- a/src/test/java/com/leeforgiveness/memberservice/subscribe/auction/AuctionSubscribeTest.java
+++ b/src/test/java/com/leeforgiveness/memberservice/subscribe/auction/AuctionSubscribeTest.java
@@ -246,7 +246,7 @@ public class AuctionSubscribeTest {
     }
 
     @ParameterizedTest
-    @DisplayName("사용자가 구독한 경매글이 없다면 어떤 값을 요청해도 빈 페이지가 조회된다.")
+    @DisplayName("사용자가 구독한 경매글이 없다면 예외를 발생시킨다.")
     @CsvSource(value = {"1, 3", "3, 7", "0, -10", "-1, 0"})
     void getSubscribedAuctionUuidsNoneSubscribeTest(int page, int size) {
         //given
@@ -260,15 +260,10 @@ public class AuctionSubscribeTest {
                 subscribedAuctionsRequestDto.getSize())
         )).thenReturn(Page.empty());
 
-        //when
-        SubscribedAuctionsResponseDto subscribedAuctionsResponseDto =
-            this.auctionSubscriptionService.getSubscribedAuctionUuids(subscribedAuctionsRequestDto);
-
-        //then
-        assertThat(subscribedAuctionsResponseDto.getAuctionUuids().size()).isEqualTo(0);
-        assertThat(subscribedAuctionsResponseDto.getCurrentPage()).isEqualTo(
-            PageState.DEFAULT.getPage());
-        assertThat(subscribedAuctionsResponseDto.isHasNext()).isFalse();
+        //when & then
+        assertThrows(CustomException.class,
+            () -> this.auctionSubscriptionService.getSubscribedAuctionUuids(
+                subscribedAuctionsRequestDto));
     }
 
     private static @NotNull Page<AuctionSubscription> getAuctionSubscrtiptionsPage(

--- a/src/test/java/com/leeforgiveness/memberservice/subscribe/seller/SellerSubscribeTest.java
+++ b/src/test/java/com/leeforgiveness/memberservice/subscribe/seller/SellerSubscribeTest.java
@@ -296,7 +296,7 @@ public class SellerSubscribeTest {
     }
 
     @ParameterizedTest
-    @DisplayName("사용자가 아무도 구독하지 않았다면 어떤 값을 요청해도 빈 페이지가 조회된다.")
+    @DisplayName("사용자가 아무도 구독하지 않았다면 예외를 발생시킨다.")
     @CsvSource(value = {"0, 5", "10, 3", "1, 10"})
     void getSubscribedSellerHandlesNoneSubscribeTest(int page, int size) {
         //when
@@ -317,15 +317,9 @@ public class SellerSubscribeTest {
         Mockito.when(memberRepository.findByUuidIn(getSellerUuids(sellerSubscriptionPage)))
             .thenReturn(getMockMembers(sellerSubscriptionPage));
 
-        //when
-        SubscribedSellersResponseDto subscribedSellersResponseDto = sellerSubscriptionService.getSubscribedSellerHandles(
-            subscribedSellersRequestDto);
-
-        //then
-        assertThat(subscribedSellersResponseDto.getSellerHandles().size()).isEqualTo(0);
-        assertThat(subscribedSellersResponseDto.getCurrentPage()).isEqualTo(
-            PageState.DEFAULT.getPage());
-        assertThat(subscribedSellersResponseDto.isHasNext()).isFalse();
+        //when & then
+        assertThrows(CustomException.class, () -> sellerSubscriptionService.getSubscribedSellerHandles(
+            subscribedSellersRequestDto));
     }
 
     private static @NotNull Page<SellerSubscription> getSellerSubscriptionsPage(


### PR DESCRIPTION
- 구독 조회 시 데이터베이스에 저장된 데이터가 없다면 예외를 발생시키는지 검증하는 테스트 코드로 수정했습니다.
- 인증 메시지 발송 API URL을 certify로 수정했습니다. 