### PR TITLE
fix: Service에 StreamBridge mock 객체 주입

### DIFF
--- a/src/test/java/com/leeforgiveness/memberservice/subscribe/seller/SellerSubscribeTest.java
+++ b/src/test/java/com/leeforgiveness/memberservice/subscribe/seller/SellerSubscribeTest.java
@@ -15,8 +15,10 @@ import com.leeforgiveness.memberservice.subscribe.dto.SellerSubscribeRequestDto;
 import com.leeforgiveness.memberservice.subscribe.dto.SubscribedSellersRequestDto;
 import com.leeforgiveness.memberservice.subscribe.dto.SubscribedSellersResponseDto;
 import com.leeforgiveness.memberservice.subscribe.infrastructure.SellerSubscriptionRepository;
+import com.leeforgiveness.memberservice.subscribe.message.SellerSubscriptionMessage;
 import com.leeforgiveness.memberservice.subscribe.state.PageState;
 import com.leeforgiveness.memberservice.subscribe.state.SubscribeState;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
+import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -36,7 +39,7 @@ public class SellerSubscribeTest {
     private SellerSubscriptionRepository sellerSubscriptionRepository = Mockito.mock(
         SellerSubscriptionRepository.class);
     private MemberRepository memberRepository = Mockito.mock(MemberRepository.class);
-
+    private StreamBridge streamBridge = Mockito.mock(StreamBridge.class);
     private SellerSubscriptionServiceImpl sellerSubscriptionService;
 
     private String subscriberUuid;
@@ -47,7 +50,7 @@ public class SellerSubscribeTest {
     @BeforeEach
     public void setUp() {
         sellerSubscriptionService = new SellerSubscriptionServiceImpl(
-            sellerSubscriptionRepository, memberRepository);
+            sellerSubscriptionRepository, memberRepository, streamBridge);
 
         subscriberUuid = GenerateRandom.subscriberUuid();
         sellerUuid = GenerateRandom.sellerUuid();
@@ -61,6 +64,12 @@ public class SellerSubscribeTest {
             .handle(sellerHandle)
             .terminationStatus(false)
             .build();
+
+        Mockito.when(streamBridge.send("sellerSubscription", SellerSubscriptionMessage.builder()
+            .sellerUuid(sellerUuid)
+            .subscribeState(SubscribeState.SUBSCRIBE)
+            .eventTime(LocalDateTime.now())
+            .build())).thenReturn(true);
     }
 
     @Test


### PR DESCRIPTION
- #111 구독 서비스레이어 테스트 수정
- StreamBridge mock 객체를 서비스 객체에 주입하도록 수정했습니다.