### PR TITLE
feat: 경매글 구독 여부 조회 API 구현

### DIFF
--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/application/AuctionSubscriptionService.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/application/AuctionSubscriptionService.java
@@ -12,4 +12,6 @@ public interface AuctionSubscriptionService {
 
     SubscribedAuctionsResponseDto getSubscribedAuctionUuids(
         SubscribedAuctionsRequestDto subscribedAuctionsRequestDto);
+
+    boolean getIsSubscribed(String memberUuid, String auctionUuid);
 }

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/application/AuctionSubscriptionServiceImpl.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/application/AuctionSubscriptionServiceImpl.java
@@ -48,6 +48,10 @@ public class AuctionSubscriptionServiceImpl implements AuctionSubscriptionServic
             //구독 취소했던 경매글을 다시 구독
             subscribeCanceledAuction(auctionSubscriptionOptional.get());
         }
+        //TODO: 자신의 경매글을 구독하지 못하도록 수정
+//        else if () {
+//
+//        }
 
         streamBridge.send("auctionSubscription", AuctionSubscriptionMessage.builder()
             .auctionUuid(auctionSubscribeRequestDto.getAuctionUuid())
@@ -165,5 +169,15 @@ public class AuctionSubscriptionServiceImpl implements AuctionSubscriptionServic
             .currentPage(page)
             .hasNext(auctionSubscriptionPage.hasNext())
             .build();
+    }
+
+    @Override
+    public boolean getIsSubscribed(String memberUuid, String auctionUuid) {
+        Optional<AuctionSubscription> auctionSubscriptionOptional =
+            this.auctionSubscriptionRepository.findBySubscriberUuidAndAuctionUuid(memberUuid,
+                auctionUuid);
+
+        return auctionSubscriptionOptional.isPresent()
+            && auctionSubscriptionOptional.get().getState() == SubscribeState.SUBSCRIBE;
     }
 }

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/application/AuctionSubscriptionServiceImpl.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/application/AuctionSubscriptionServiceImpl.java
@@ -177,7 +177,9 @@ public class AuctionSubscriptionServiceImpl implements AuctionSubscriptionServic
             this.auctionSubscriptionRepository.findBySubscriberUuidAndAuctionUuid(memberUuid,
                 auctionUuid);
 
-        return auctionSubscriptionOptional.isPresent()
-            && auctionSubscriptionOptional.get().getState() == SubscribeState.SUBSCRIBE;
+        if (auctionSubscriptionOptional.isEmpty()) {
+            throw new CustomException(ResponseStatus.NO_DATA);
+        }
+        return auctionSubscriptionOptional.get().getState() == SubscribeState.SUBSCRIBE;
     }
 }

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/presentation/AuctionSubscriptionController.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/presentation/AuctionSubscriptionController.java
@@ -6,6 +6,7 @@ import com.leeforgiveness.memberservice.subscribe.dto.AuctionSubscribeRequestDto
 import com.leeforgiveness.memberservice.subscribe.dto.SubscribedAuctionsRequestDto;
 import com.leeforgiveness.memberservice.subscribe.dto.SubscribedAuctionsResponseDto;
 import com.leeforgiveness.memberservice.subscribe.vo.AuctionSubscribeRequestVo;
+import com.leeforgiveness.memberservice.subscribe.vo.IsSubscribedResponseVo;
 import com.leeforgiveness.memberservice.subscribe.vo.SubscribedAuctionsResponseVo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -60,5 +61,17 @@ public class AuctionSubscriptionController {
             SubscribedAuctionsResponseDto.dtoToVo(
                 this.auctionSubscriptionService.getSubscribedAuctionUuids(
                     SubscribedAuctionsRequestDto.validate(uuid, page, size))));
+    }
+
+    @GetMapping("/is-subscribed")
+    @Operation(summary = "경매글 구독 여부 조회", description = "경매글 구독 여부를 조회합니다.")
+    public SuccessResponse<IsSubscribedResponseVo> getIsSubscribed(
+        @RequestHeader String uuid,
+        @RequestParam(value = "auctionUuid") String auctionUuid
+    ) {
+        return new SuccessResponse<>(
+            new IsSubscribedResponseVo(
+                this.auctionSubscriptionService.getIsSubscribed(uuid, auctionUuid))
+        );
     }
 }

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/vo/IsSubscribedResponseVo.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/vo/IsSubscribedResponseVo.java
@@ -1,0 +1,5 @@
+package com.leeforgiveness.memberservice.subscribe.vo;
+
+public record IsSubscribedResponseVo(boolean isSubscribed) {
+
+}


### PR DESCRIPTION
- #128 
- 프론트 요청에따라 경매글 구독 여부를 boolean으로 반환하는 API를 구현했습니다.
- 프론트에서 에러가 발생하면 false로 반환하도록 요청해서 예외처리를 하지 않았습니다.
- 요청이 들어오면 vo나 dto를 거치지 않고 바로 받도록 했습니다. 리소스 낭비라고 생각하는데 거쳐야 할까요?
- 반환하는 값은 false로 같지만 에러 분기처리를 해야할지 고민입니다.