### PR TITLE
Refactor/#123

### DIFF
--- a/src/main/java/com/leeforgiveness/memberservice/common/exception/ResponseStatus.java
+++ b/src/main/java/com/leeforgiveness/memberservice/common/exception/ResponseStatus.java
@@ -100,6 +100,7 @@ public enum ResponseStatus {
 
     //subscribe
     DUPLICATE_SUBSCRIBE(400, "이미 구독 중입니다."),
+    SELF_SUBSCRIBE(300, "자기 자신 또는 자신의 경매글입니다."),
     UNSUBSCRIBED_SELLER(400, "구독하지 않은 판매자입니다."),
     UNSUBSCRIBED_AUCTION(400, "구독하지 않은 경매글입니다."),
     DATABASE_READ_FAIL(500, "데이터베이스 데이터 조회에 실패했습니다."),

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/application/AuctionSubscriptionServiceImpl.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/application/AuctionSubscriptionServiceImpl.java
@@ -7,10 +7,8 @@ import com.leeforgiveness.memberservice.subscribe.dto.AuctionSubscribeRequestDto
 import com.leeforgiveness.memberservice.subscribe.dto.SubscribedAuctionsRequestDto;
 import com.leeforgiveness.memberservice.subscribe.dto.SubscribedAuctionsResponseDto;
 import com.leeforgiveness.memberservice.subscribe.infrastructure.AuctionSubscriptionRepository;
-import com.leeforgiveness.memberservice.subscribe.message.AuctionSubscriptionMessage;
 import com.leeforgiveness.memberservice.subscribe.state.PageState;
 import com.leeforgiveness.memberservice.subscribe.state.SubscribeState;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -176,10 +174,7 @@ public class AuctionSubscriptionServiceImpl implements AuctionSubscriptionServic
         Optional<AuctionSubscription> auctionSubscriptionOptional =
             this.auctionSubscriptionRepository.findBySubscriberUuidAndAuctionUuid(memberUuid,
                 auctionUuid);
-
-        if (auctionSubscriptionOptional.isEmpty()) {
-            throw new CustomException(ResponseStatus.NO_DATA);
-        }
-        return auctionSubscriptionOptional.get().getState() == SubscribeState.SUBSCRIBE;
+        return auctionSubscriptionOptional.isPresent()
+            && auctionSubscriptionOptional.get().getState() == SubscribeState.SUBSCRIBE;
     }
 }

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/application/AuctionSubscriptionServiceImpl.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/application/AuctionSubscriptionServiceImpl.java
@@ -53,11 +53,11 @@ public class AuctionSubscriptionServiceImpl implements AuctionSubscriptionServic
 //
 //        }
 
-        streamBridge.send("auctionSubscription", AuctionSubscriptionMessage.builder()
-            .auctionUuid(auctionSubscribeRequestDto.getAuctionUuid())
-            .subscribeState(SubscribeState.SUBSCRIBE)
-            .eventTime(LocalDateTime.now())
-            .build());
+//        streamBridge.send("auctionSubscription", AuctionSubscriptionMessage.builder()
+//            .auctionUuid(auctionSubscribeRequestDto.getAuctionUuid())
+//            .subscribeState(SubscribeState.SUBSCRIBE)
+//            .eventTime(LocalDateTime.now())
+//            .build());
     }
 
     private void subscribeCanceledAuction(AuctionSubscription auctionSubscription) {
@@ -137,11 +137,11 @@ public class AuctionSubscriptionServiceImpl implements AuctionSubscriptionServic
         int size = subscribedAuctionsRequestDto.getSize();
 
         if (page < 0) {
-            page = PageState.DEFAULT.getPage();
+            page = PageState.AUCTION.getPage();
         }
 
         if (size <= 0) {
-            size = PageState.DEFAULT.getSize();
+            size = PageState.AUCTION.getSize();
         }
 
         Page<AuctionSubscription> auctionSubscriptionPage = Page.empty();

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/application/SellerSubscriptionServiceImpl.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/application/SellerSubscriptionServiceImpl.java
@@ -65,6 +65,8 @@ public class SellerSubscriptionServiceImpl implements SellerSubscriptionService 
                 .subscriberUuid(subscriberUuid)
                 .sellerUuid(sellerUuid)
                 .build());
+        } else if (subscriberUuid.equals(sellerUuid)) {
+            throw new CustomException(ResponseStatus.SELF_SUBSCRIBE);
         } else if (sellerSubscriptionOptional.get().getState() == SubscribeState.SUBSCRIBE) {
             throw new CustomException(ResponseStatus.DUPLICATE_SUBSCRIBE);
         } else if (sellerSubscriptionOptional.get().getState() == SubscribeState.UNSUBSCRIBE) {
@@ -157,11 +159,11 @@ public class SellerSubscriptionServiceImpl implements SellerSubscriptionService 
         int size = subscribedSellersRequestDto.getSize();
 
         if (page < 0) {
-            page = PageState.DEFAULT.getPage();
+            page = PageState.SELLER.getPage();
         }
 
         if (size <= 0) {
-            size = PageState.DEFAULT.getSize();
+            size = PageState.SELLER.getSize();
         }
 
         Page<SellerSubscription> sellerSubscriptionPage = Page.empty();

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/SubscribedAuctionsRequestDto.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/SubscribedAuctionsRequestDto.java
@@ -20,11 +20,11 @@ public class SubscribedAuctionsRequestDto {
         String uuid, Integer page, Integer size
     ) {
         if (page == null || page < 0) {
-            page = PageState.DEFAULT.getPage();
+            page = PageState.AUCTION.getPage();
         }
 
         if (size == null || size <= 0) {
-            size = PageState.DEFAULT.getSize();
+            size = PageState.AUCTION.getSize();
         }
 
         return SubscribedAuctionsRequestDto.builder()

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/SubscribedSellersRequestDto.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/SubscribedSellersRequestDto.java
@@ -22,11 +22,11 @@ public class SubscribedSellersRequestDto {
         String uuid, Integer page, Integer size) {
 
         if (page == null || page < 0) {
-            page = PageState.DEFAULT.getPage();
+            page = PageState.SELLER.getPage();
         }
 
         if (size == null || size <= 0) {
-            size = PageState.DEFAULT.getSize();
+            size = PageState.SELLER.getSize();
         }
 
         return SubscribedSellersRequestDto.builder()

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/state/PageState.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/state/PageState.java
@@ -4,7 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum PageState {
-    DEFAULT(0, 5);
+    AUCTION(0, 5),
+    SELLER(0, 10);
 
     private int page;
     private int size;


### PR DESCRIPTION
- #123 일부 완료했습니다.
- 자기자신을 구독하려고 하면 예외로 처리합니다.
- 프론트 측 요청에따라 판매자 구독 내역 페이징 사이즈 기본값을 10으로 수정했습니다.
- 경매 구독 여부 조회 로직을 다시 의논한 결과, 구독 테이블에 데이터가 없으면 반드시 구독하지 않은 상태이므로 예외를 발생시키기 보다 false를 반환하도록 수정했습니다.