### PR TITLE
refactor: 구독 여부 조회 API 헤더에 authorization 추가

### DIFF
--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/presentation/AuctionSubscriptionController.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/presentation/AuctionSubscriptionController.java
@@ -66,6 +66,7 @@ public class AuctionSubscriptionController {
     @GetMapping("/is-subscribed")
     @Operation(summary = "경매글 구독 여부 조회", description = "경매글 구독 여부를 조회합니다.")
     public SuccessResponse<IsSubscribedResponseVo> getIsSubscribed(
+        @RequestHeader String authorization,
         @RequestHeader String uuid,
         @RequestParam(value = "auctionUuid") String auctionUuid
     ) {


### PR DESCRIPTION
- #123 
- 경매글 구독 여부 조회 API 헤더에 authorization 추가하여 API를 호출할때 authorization을 필수 전달하도록 했습니다.