### PR TITLE
Refactor/#174

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 
     // Logstash
     implementation 'net.logstash.logback:logstash-logback-encoder:6.2'
+
+    // webflux
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/leeforgiveness/memberservice/common/ServerPath.java
+++ b/src/main/java/com/leeforgiveness/memberservice/common/ServerPath.java
@@ -1,0 +1,14 @@
+package com.leeforgiveness.memberservice.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ServerPath {
+
+    AUCTION_SERVICE("http://52.79.127.196:8000/auction-service"),
+    GET_AUCTION_POST_DETAIL("/api/v1/non-authorization/auction/{auctionUuid}");
+
+    private final String server;
+}

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/AuctionAndIsSubscribedDto.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/AuctionAndIsSubscribedDto.java
@@ -1,0 +1,37 @@
+package com.leeforgiveness.memberservice.subscribe.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AuctionAndIsSubscribedDto {
+    private String auctionUuid;
+    private String handle;
+    private String sellerUuid;
+    private String title;
+    private String content;
+    private String category;
+    private int minimumBiddingPrice;
+    private String thumbnail;
+    private LocalDateTime createdAt;
+    private LocalDateTime endedAt;
+    private boolean isSubscribed;
+
+    @Builder
+    public AuctionAndIsSubscribedDto(String auctionUuid, String handle, String sellerUuid, String title, String content, String category, int minimumBiddingPrice, String thumbnail, LocalDateTime createdAt, LocalDateTime endedAt, boolean isSubscribed) {
+        this.auctionUuid = auctionUuid;
+        this.handle = handle;
+        this.sellerUuid = sellerUuid;
+        this.title = title;
+        this.content = content;
+        this.category = category;
+        this.minimumBiddingPrice = minimumBiddingPrice;
+        this.thumbnail = thumbnail;
+        this.createdAt = createdAt;
+        this.endedAt = endedAt;
+        this.isSubscribed = isSubscribed;
+    }
+}

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/ReadOnlyAuction.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/ReadOnlyAuction.java
@@ -1,0 +1,27 @@
+package com.leeforgiveness.memberservice.subscribe.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReadOnlyAuction {
+
+    private String auctionPostId;
+    private String auctionUuid;
+    private String sellerUuid;
+    private String title;
+    private String content;
+    private String category;
+    private int minimumBiddingPrice;
+    private LocalDateTime createdAt;
+    private LocalDateTime endedAt;
+    private String bidderUuid;
+    private int bidPrice;
+    private String state;
+}

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/SubscribedAuctionsRequestDto.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/SubscribedAuctionsRequestDto.java
@@ -1,6 +1,5 @@
 package com.leeforgiveness.memberservice.subscribe.dto;
 
-import com.leeforgiveness.memberservice.subscribe.state.PageState;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,24 +12,4 @@ import lombok.Setter;
 public class SubscribedAuctionsRequestDto {
 
     private String subscriberUuid;
-    private int page;
-    private int size;
-
-    public static SubscribedAuctionsRequestDto validate(
-        String uuid, Integer page, Integer size
-    ) {
-        if (page == null || page < 0) {
-            page = PageState.AUCTION.getPage();
-        }
-
-        if (size == null || size <= 0) {
-            size = PageState.AUCTION.getSize();
-        }
-
-        return SubscribedAuctionsRequestDto.builder()
-            .subscriberUuid(uuid)
-            .page(page)
-            .size(size)
-            .build();
-    }
 }

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/SubscribedAuctionsResponseDto.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/dto/SubscribedAuctionsResponseDto.java
@@ -12,15 +12,11 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class SubscribedAuctionsResponseDto {
-    private List<String> auctionUuids;
-    private int currentPage;
-    private boolean hasNext;
+    private List<AuctionAndIsSubscribedDto> auctionAndIsSubscribedDtos;
 
     public static SubscribedAuctionsResponseVo dtoToVo(SubscribedAuctionsResponseDto subscribedAuctionsResponseDto) {
         return new SubscribedAuctionsResponseVo(
-            subscribedAuctionsResponseDto.getAuctionUuids(),
-            subscribedAuctionsResponseDto.getCurrentPage(),
-            subscribedAuctionsResponseDto.isHasNext()
+            subscribedAuctionsResponseDto.getAuctionAndIsSubscribedDtos()
         );
     }
 }

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/infrastructure/AuctionSubscriptionRepository.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/infrastructure/AuctionSubscriptionRepository.java
@@ -2,6 +2,7 @@ package com.leeforgiveness.memberservice.subscribe.infrastructure;
 
 import com.leeforgiveness.memberservice.subscribe.domain.AuctionSubscription;
 import com.leeforgiveness.memberservice.subscribe.state.SubscribeState;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,5 +12,8 @@ public interface AuctionSubscriptionRepository extends JpaRepository<AuctionSubs
 
     Optional<AuctionSubscription> findBySubscriberUuidAndAuctionUuid(String subscriberUuid, String auctionUuid);
 
+    //현재 사용하지 않는 메서드
     Page<AuctionSubscription> findBySubscriberUuidAndState(String subscriberUuid, SubscribeState subscribeState, Pageable pageable);
+
+    List<AuctionSubscription> findBySubscriberUuidAndState(String subscriberUuid, SubscribeState subscribeState);
 }

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/presentation/AuctionSubscriptionController.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/presentation/AuctionSubscriptionController.java
@@ -53,14 +53,12 @@ public class AuctionSubscriptionController {
     @GetMapping
     @Operation(summary = "경매글 구독 조회", description = "경매글 구독내역을 페이지로 조회합니다.")
     public SuccessResponse<SubscribedAuctionsResponseVo> getAuctionSubscribe(
-        @RequestHeader String uuid,
-        @RequestParam(required = false) Integer page,
-        @RequestParam(required = false) Integer size
+        @RequestHeader String uuid
     ) {
         return new SuccessResponse<>(
             SubscribedAuctionsResponseDto.dtoToVo(
                 this.auctionSubscriptionService.getSubscribedAuctionUuids(
-                    SubscribedAuctionsRequestDto.validate(uuid, page, size))));
+                    SubscribedAuctionsRequestDto.builder().subscriberUuid(uuid).build())));
     }
 
     @GetMapping("/is-subscribed")

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/vo/SearchAuctionResponseVo.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/vo/SearchAuctionResponseVo.java
@@ -1,0 +1,23 @@
+package com.leeforgiveness.memberservice.subscribe.vo;
+
+import com.leeforgiveness.memberservice.subscribe.dto.ReadOnlyAuction;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SearchAuctionResponseVo {
+
+    private ReadOnlyAuction readOnlyAuction;
+    private String handle;
+    private String thumbnail;
+    private List<String> images;
+    private boolean isSubscribed;
+}

--- a/src/main/java/com/leeforgiveness/memberservice/subscribe/vo/SubscribedAuctionsResponseVo.java
+++ b/src/main/java/com/leeforgiveness/memberservice/subscribe/vo/SubscribedAuctionsResponseVo.java
@@ -1,8 +1,9 @@
 package com.leeforgiveness.memberservice.subscribe.vo;
 
+import com.leeforgiveness.memberservice.subscribe.dto.AuctionAndIsSubscribedDto;
 import java.util.List;
 
-public record SubscribedAuctionsResponseVo(List<String> auctionUuids, int currentPage,
-                                           boolean hasNext) {
+public record SubscribedAuctionsResponseVo(
+    List<AuctionAndIsSubscribedDto> auctionAndIsSubscribedDtos) {
 
 }


### PR DESCRIPTION
- #174 
- 프론트측 요청에따라 경매글 리스트 조회 시 경매글 상세 정보를 반환하도록 수정했습니다.
![image](https://github.com/SKY-HORSE-MAN-POWER/BE_Members/assets/100576111/c5a527db-0270-4577-9cc4-4cde76e19f8d)

- 구독한 auctionUuid마다 기존 경매 서비스의 경매글 상세조회 API를 호출하기 때문에 여러번 통신해야하는 문제가 있습니다.
- 모든 auctionUuid를 넘겨주면 해당 경매글 데이터들을 주는 API가 필요합니다.
- 경매글 데이터를 받아오는 단위 테스트를 하려했으나, webClient를 mock으로 설정하는 부분이 까다로워 postman으로 테스트했습니다.