### PR TITLE
refactor: sms 인증 API CORS 설정

### DIFF
--- a/src/main/java/com/leeforgiveness/memberservice/sms/presentation/SmsController.java
+++ b/src/main/java/com/leeforgiveness/memberservice/sms/presentation/SmsController.java
@@ -8,11 +8,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@CrossOrigin(value = "*")
 @Slf4j
 @RestController
 @RequiredArgsConstructor


### PR DESCRIPTION
- [x] #195 
- `SmsController`에 `@CrossOrigin(value = "*")`을 추가했습니다.