### PR TITLE
feat: 카프카 메시지의 uuid로 프로필 이미지 조회 후 반환 및 설정 수정

### DIFF
--- a/src/main/java/com/leeforgiveness/memberservice/auth/application/MemberService.java
+++ b/src/main/java/com/leeforgiveness/memberservice/auth/application/MemberService.java
@@ -10,6 +10,8 @@ import com.leeforgiveness.memberservice.auth.dto.SellerMemberDetailRequestDto;
 import com.leeforgiveness.memberservice.auth.dto.SellerMemberDetailResponseDto;
 import com.leeforgiveness.memberservice.auth.dto.SnsMemberAddRequestDto;
 import com.leeforgiveness.memberservice.auth.dto.TokenResponseDto;
+import com.leeforgiveness.memberservice.auth.vo.SearchForChatRoomVo;
+import java.util.Map;
 
 public interface MemberService {
 
@@ -29,4 +31,6 @@ public interface MemberService {
 	void addReport(String uuid, MemberReportRequestDto memberReportRequestDto);
 
 	TokenResponseDto tokenReIssue(String receiveToken, String uuid);
+
+    void searchProfileImage(SearchForChatRoomVo searchForChatRoomVo);
 }

--- a/src/main/java/com/leeforgiveness/memberservice/auth/application/MemberServiceImpl.java
+++ b/src/main/java/com/leeforgiveness/memberservice/auth/application/MemberServiceImpl.java
@@ -9,6 +9,7 @@ import com.leeforgiveness.memberservice.auth.dto.MemberReportRequestDto;
 import com.leeforgiveness.memberservice.auth.dto.MemberSnsLoginRequestDto;
 import com.leeforgiveness.memberservice.auth.dto.MemberUpdateRequestDto;
 import com.leeforgiveness.memberservice.auth.dto.MemberUuidResponseDto;
+import com.leeforgiveness.memberservice.auth.dto.MemberUuidsWithProfilesDto;
 import com.leeforgiveness.memberservice.auth.dto.SellerMemberDetailRequestDto;
 import com.leeforgiveness.memberservice.auth.dto.SellerMemberDetailResponseDto;
 import com.leeforgiveness.memberservice.auth.dto.SnsMemberAddRequestDto;
@@ -18,8 +19,12 @@ import com.leeforgiveness.memberservice.auth.infrastructure.RefreshTokenCertific
 import com.leeforgiveness.memberservice.auth.infrastructure.SnsInfoRepository;
 
 import com.leeforgiveness.memberservice.auth.infrastructure.UserReportRepository;
+import com.leeforgiveness.memberservice.auth.vo.SearchForChatRoomVo;
 import com.leeforgiveness.memberservice.common.exception.CustomException;
 import com.leeforgiveness.memberservice.common.exception.ResponseStatus;
+import com.leeforgiveness.memberservice.common.kafka.KafkaProducerCluster;
+import com.leeforgiveness.memberservice.common.kafka.Topics;
+import com.leeforgiveness.memberservice.common.kafka.Topics.Constant;
 import com.leeforgiveness.memberservice.common.security.JwtTokenProvider;
 import com.leeforgiveness.memberservice.subscribe.infrastructure.SellerSubscriptionRepository;
 import com.leeforgiveness.memberservice.subscribe.state.SubscribeState;
@@ -30,6 +35,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.User;
@@ -45,231 +52,254 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
 
-	private final MemberRepository memberRepository;
-	private final SnsInfoRepository snsInfoRepository;
-	private final JwtTokenProvider jwtTokenProvider;
-	private final UserReportRepository userReportRepository;
-	private final SellerSubscriptionRepository sellerSubscriptionRepository;
-	private final RefreshTokenCertification refreshTokenCertification;
+    private final MemberRepository memberRepository;
+    private final SnsInfoRepository snsInfoRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserReportRepository userReportRepository;
+    private final SellerSubscriptionRepository sellerSubscriptionRepository;
+    private final RefreshTokenCertification refreshTokenCertification;
+    private final KafkaProducerCluster producer;
 
-	//이메일 중복 확인
-	private void checkEmailDuplicate(String email) {
-		if (memberRepository.findByEmail(email).isPresent()) {
-			throw new CustomException(ResponseStatus.DUPLICATE_EMAIL);
-		}
-	}
+    //이메일 중복 확인
+    private void checkEmailDuplicate(String email) {
+        if (memberRepository.findByEmail(email).isPresent()) {
+            throw new CustomException(ResponseStatus.DUPLICATE_EMAIL);
+        }
+    }
 
-	//휴대폰 번호 중복 확인
-	private void checkPhoneNumberDuplicate(String phoneNum) {
-		if (memberRepository.findByPhoneNum(phoneNum).isPresent()) {
-			throw new CustomException(ResponseStatus.DUPLICATE_PHONE_NUMBER);
-		}
-	}
+    //휴대폰 번호 중복 확인
+    private void checkPhoneNumberDuplicate(String phoneNum) {
+        if (memberRepository.findByPhoneNum(phoneNum).isPresent()) {
+            throw new CustomException(ResponseStatus.DUPLICATE_PHONE_NUMBER);
+        }
+    }
 
-	//SNS 회원 추가
-	@Override
-	@Transactional
-	public void snsAddMember(SnsMemberAddRequestDto snsMemberAddRequestDto) {
-		if (snsInfoRepository.findBySnsIdAndSnsType(snsMemberAddRequestDto.getSnsId(),
-			snsMemberAddRequestDto.getSnsType()).isPresent()) {
-			throw new CustomException(ResponseStatus.DUPLICATED_MEMBERS);
-		}
+    //SNS 회원 추가
+    @Override
+    @Transactional
+    public void snsAddMember(SnsMemberAddRequestDto snsMemberAddRequestDto) {
+        if (snsInfoRepository.findBySnsIdAndSnsType(snsMemberAddRequestDto.getSnsId(),
+            snsMemberAddRequestDto.getSnsType()).isPresent()) {
+            throw new CustomException(ResponseStatus.DUPLICATED_MEMBERS);
+        }
 
-		//이메일 중복 확인
-		checkEmailDuplicate(snsMemberAddRequestDto.getEmail());
+        //이메일 중복 확인
+        checkEmailDuplicate(snsMemberAddRequestDto.getEmail());
 
-		//휴대폰 번호 중복 확인
-		checkPhoneNumberDuplicate(snsMemberAddRequestDto.getPhoneNum());
+        //휴대폰 번호 중복 확인
+        checkPhoneNumberDuplicate(snsMemberAddRequestDto.getPhoneNum());
 
-		String uuid = UUID.randomUUID().toString();
+        String uuid = UUID.randomUUID().toString();
 
-		Member member = Member.builder()
-			.email(snsMemberAddRequestDto.getEmail())
-			.name(snsMemberAddRequestDto.getName())
-			.phoneNum(snsMemberAddRequestDto.getPhoneNum())
-			.uuid(uuid)
-			.profileImage(
-				"https://ifh.cc/g/Vv1lrR.png")
-			.build();
+        Member member = Member.builder()
+            .email(snsMemberAddRequestDto.getEmail())
+            .name(snsMemberAddRequestDto.getName())
+            .phoneNum(snsMemberAddRequestDto.getPhoneNum())
+            .uuid(uuid)
+            .profileImage(
+                "https://ifh.cc/g/Vv1lrR.png")
+            .build();
 
-		memberRepository.save(member);
+        memberRepository.save(member);
 
-		SnsInfo snsInfo = SnsInfo.builder()
-			.snsId(snsMemberAddRequestDto.getSnsId())
-			.snsType(snsMemberAddRequestDto.getSnsType())
-			.member(member)
-			.build();
+        SnsInfo snsInfo = SnsInfo.builder()
+            .snsId(snsMemberAddRequestDto.getSnsId())
+            .snsType(snsMemberAddRequestDto.getSnsType())
+            .member(member)
+            .build();
 
-		snsInfoRepository.save(snsInfo);
-	}
+        snsInfoRepository.save(snsInfo);
+    }
 
-	//	토큰 생성
-	private String createToken(Member member) {
-		UserDetails userDetails = User.withUsername(member.getUuid()).password(member.getUuid())
-			.roles("USER").build();
-		return jwtTokenProvider.generateToken(userDetails);
-	}
+    //	토큰 생성
+    private String createToken(Member member) {
+        UserDetails userDetails = User.withUsername(member.getUuid()).password(member.getUuid())
+            .roles("USER").build();
+        return jwtTokenProvider.generateToken(userDetails);
+    }
 
-	//리프레쉬 토큰 생성
-	private String createRefreshToken(Member member) {
-		UserDetails userDetails = User.withUsername(member.getUuid()).password(member.getUuid())
-			.roles("USER").build();
-		return jwtTokenProvider.generateRefreshToken(userDetails);
-	}
+    //리프레쉬 토큰 생성
+    private String createRefreshToken(Member member) {
+        UserDetails userDetails = User.withUsername(member.getUuid()).password(member.getUuid())
+            .roles("USER").build();
+        return jwtTokenProvider.generateRefreshToken(userDetails);
+    }
 
-	//	소셜 로그인
-	@Override
-	@Transactional
-	public TokenResponseDto snsLogin(MemberSnsLoginRequestDto memberSnsLoginRequestDto) {
-		SnsInfo snsInfo = snsInfoRepository.findBySnsIdAndSnsType(
-				memberSnsLoginRequestDto.getSnsId(), memberSnsLoginRequestDto.getSnsType())
-			.orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
-		Member member = memberRepository.findByEmail(memberSnsLoginRequestDto.getEmail())
-			.orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
-		if (member.isTerminationStatus()) {
-			throw new CustomException(ResponseStatus.WITHDRAWAL_MEMBERS);
-		}
+    //	소셜 로그인
+    @Override
+    @Transactional
+    public TokenResponseDto snsLogin(MemberSnsLoginRequestDto memberSnsLoginRequestDto) {
+        SnsInfo snsInfo = snsInfoRepository.findBySnsIdAndSnsType(
+                memberSnsLoginRequestDto.getSnsId(), memberSnsLoginRequestDto.getSnsType())
+            .orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
+        Member member = memberRepository.findByEmail(memberSnsLoginRequestDto.getEmail())
+            .orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
+        if (member.isTerminationStatus()) {
+            throw new CustomException(ResponseStatus.WITHDRAWAL_MEMBERS);
+        }
 
-		String token = createToken(member);
-		String refreshToken = createRefreshToken(member);
+        String token = createToken(member);
+        String refreshToken = createRefreshToken(member);
 
-		refreshTokenCertification.saveRefreshToken(member.getUuid(), refreshToken);
+        refreshTokenCertification.saveRefreshToken(member.getUuid(), refreshToken);
 
-		return TokenResponseDto.builder()
-			.accessToken(token)
-			.refreshToken(refreshToken)
-			.uuid(member.getUuid())
-			.build();
-	}
+        return TokenResponseDto.builder()
+            .accessToken(token)
+            .refreshToken(refreshToken)
+            .uuid(member.getUuid())
+            .build();
+    }
 
-	//토큰 재발급
-	@Override
-	public TokenResponseDto tokenReIssue(String receiveToken, String uuid) {
-		Member member = memberRepository.findByUuid(uuid)
-			.orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
-		if (member.isTerminationStatus()) {
-			throw new CustomException(ResponseStatus.WITHDRAWAL_MEMBERS);
-		}
-		if (refreshTokenCertification.hasKey(uuid) && refreshTokenCertification.getRefreshToken(
-			uuid).equals(receiveToken)) {
-			String token = createToken(member);
-			return TokenResponseDto.builder()
-				.accessToken(token)
-				.refreshToken(null)
-				.uuid(member.getUuid())
-				.build();
-		} else {
-			throw new CustomException(ResponseStatus.TOKEN_NOT_VALID);
-		}
-	}
+    //토큰 재발급
+    @Override
+    public TokenResponseDto tokenReIssue(String receiveToken, String uuid) {
+        Member member = memberRepository.findByUuid(uuid)
+            .orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
+        if (member.isTerminationStatus()) {
+            throw new CustomException(ResponseStatus.WITHDRAWAL_MEMBERS);
+        }
+        if (refreshTokenCertification.hasKey(uuid) && refreshTokenCertification.getRefreshToken(
+            uuid).equals(receiveToken)) {
+            String token = createToken(member);
+            return TokenResponseDto.builder()
+                .accessToken(token)
+                .refreshToken(null)
+                .uuid(member.getUuid())
+                .build();
+        } else {
+            throw new CustomException(ResponseStatus.TOKEN_NOT_VALID);
+        }
+    }
 
-	//회원정보 조회
-	@Override
-	public MemberDetailResponseDto findMember(String uuid) {
-		Member member = memberRepository.findByUuid(uuid)
-			.orElseThrow(() -> new CustomException(ResponseStatus.NO_EXIST_MEMBERS));
+    //회원정보 조회
+    @Override
+    public MemberDetailResponseDto findMember(String uuid) {
+        Member member = memberRepository.findByUuid(uuid)
+            .orElseThrow(() -> new CustomException(ResponseStatus.NO_EXIST_MEMBERS));
 
-		return MemberDetailResponseDto.builder()
-			.email(member.getEmail())
-			.name(member.getName())
-			.phoneNum(member.getPhoneNum())
-			.profileImage(member.getProfileImage())
-			.build();
-	}
+        return MemberDetailResponseDto.builder()
+            .email(member.getEmail())
+            .name(member.getName())
+            .phoneNum(member.getPhoneNum())
+            .profileImage(member.getProfileImage())
+            .build();
+    }
 
-	//회원정보 수정
-	@Override
-	@Transactional
-	public void updateMember(String memberUuid,
-		MemberUpdateRequestDto memberUpdateRequestDto) {
-		Member member = memberRepository.findByUuid(memberUuid)
-			.orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
+    //회원정보 수정
+    @Override
+    @Transactional
+    public void updateMember(String memberUuid,
+        MemberUpdateRequestDto memberUpdateRequestDto) {
+        Member member = memberRepository.findByUuid(memberUuid)
+            .orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
 
-		//휴대폰번호 중복 확인
-		if (!member.getPhoneNum().equals(memberUpdateRequestDto.getPhoneNum())) {
-			checkPhoneNumberDuplicate(memberUpdateRequestDto.getPhoneNum());
-		}
+        //휴대폰번호 중복 확인
+        if (!member.getPhoneNum().equals(memberUpdateRequestDto.getPhoneNum())) {
+            checkPhoneNumberDuplicate(memberUpdateRequestDto.getPhoneNum());
+        }
 
-		memberRepository.save(Member.builder()
-			.id(member.getId())
-			.uuid(member.getUuid())
-			.email(member.getEmail())
-			.name(memberUpdateRequestDto.getName())
-			.phoneNum(memberUpdateRequestDto.getPhoneNum())
-			.profileImage(memberUpdateRequestDto.getProfileImage())
-			.terminationStatus(member.isTerminationStatus())
-			.build()
-		);
-	}
+        memberRepository.save(Member.builder()
+            .id(member.getId())
+            .uuid(member.getUuid())
+            .email(member.getEmail())
+            .name(memberUpdateRequestDto.getName())
+            .phoneNum(memberUpdateRequestDto.getPhoneNum())
+            .profileImage(memberUpdateRequestDto.getProfileImage())
+            .terminationStatus(member.isTerminationStatus())
+            .build()
+        );
+    }
 
-	//회원 탈퇴
-	@Override
-	@Transactional
-	public void removeMember(String uuid) {
-		Member member = memberRepository.findByUuid(uuid)
-			.orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
+    //회원 탈퇴
+    @Override
+    @Transactional
+    public void removeMember(String uuid) {
+        Member member = memberRepository.findByUuid(uuid)
+            .orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
 
-		memberRepository.save(Member.builder()
-			.id(member.getId())
-			.uuid(member.getUuid())
-			.email(member.getEmail())
-			.name(member.getName())
-			.phoneNum(member.getPhoneNum())
-			.terminationStatus(true)
-			.profileImage(member.getProfileImage())
-			.build()
-		);
-	}
+        memberRepository.save(Member.builder()
+            .id(member.getId())
+            .uuid(member.getUuid())
+            .email(member.getEmail())
+            .name(member.getName())
+            .phoneNum(member.getPhoneNum())
+            .terminationStatus(true)
+            .profileImage(member.getProfileImage())
+            .build()
+        );
+    }
 
-	//판매자 회원정보 조회
-	@Override
-	public SellerMemberDetailResponseDto findSellerMember(
-		SellerMemberDetailRequestDto sellerMemberDetailRequestDto) {
-		Member member = memberRepository.findByUuid(sellerMemberDetailRequestDto.getUuid())
-			.orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
+    //판매자 회원정보 조회
+    @Override
+    public SellerMemberDetailResponseDto findSellerMember(
+        SellerMemberDetailRequestDto sellerMemberDetailRequestDto) {
+        Member member = memberRepository.findByUuid(sellerMemberDetailRequestDto.getUuid())
+            .orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
 
-		boolean isSubscribed = false;
-		if (sellerMemberDetailRequestDto.getUuid() != null) {
-			if (sellerSubscriptionRepository.findBySubscriberUuidAndSellerUuid(
-				sellerMemberDetailRequestDto.getUuid(), member.getUuid()).isEmpty()) {
-				isSubscribed = false;
-			} else if (sellerSubscriptionRepository.findBySubscriberUuidAndSellerUuid(
-					sellerMemberDetailRequestDto.getUuid(), member.getUuid())
-				.get().getState() == SubscribeState.SUBSCRIBE) {
-				isSubscribed = true;
-			} else if (sellerSubscriptionRepository.findBySubscriberUuidAndSellerUuid(
-					sellerMemberDetailRequestDto.getUuid(), member.getUuid())
-				.get().getState() == SubscribeState.UNSUBSCRIBE) {
-				isSubscribed = false;
+        boolean isSubscribed = false;
+        if (sellerMemberDetailRequestDto.getUuid() != null) {
+            if (sellerSubscriptionRepository.findBySubscriberUuidAndSellerUuid(
+                sellerMemberDetailRequestDto.getUuid(), member.getUuid()).isEmpty()) {
+                isSubscribed = false;
+            } else if (sellerSubscriptionRepository.findBySubscriberUuidAndSellerUuid(
+                    sellerMemberDetailRequestDto.getUuid(), member.getUuid())
+                .get().getState() == SubscribeState.SUBSCRIBE) {
+                isSubscribed = true;
+            } else if (sellerSubscriptionRepository.findBySubscriberUuidAndSellerUuid(
+                    sellerMemberDetailRequestDto.getUuid(), member.getUuid())
+                .get().getState() == SubscribeState.UNSUBSCRIBE) {
+                isSubscribed = false;
 
-			}
-		}
+            }
+        }
 
-		return SellerMemberDetailResponseDto.builder()
-			.name(member.getName())
-			.profileImage(member.getProfileImage())
-			.isSubscribed(isSubscribed)
-			.build();
-	}
+        return SellerMemberDetailResponseDto.builder()
+            .name(member.getName())
+            .profileImage(member.getProfileImage())
+            .isSubscribed(isSubscribed)
+            .build();
+    }
 
-	//회원 신고
-	@Override
-	@Transactional
-	public void addReport(String uuid, MemberReportRequestDto memberReportRequestDto) {
-		String reportedUuid = memberReportRequestDto.getReportedUuid();
-		memberRepository.findByUuid(reportedUuid)
-			.orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
-		userReportRepository.findByReporterUuidAndReportedUuid(uuid, reportedUuid)
-			.ifPresent(report -> {
-				throw new CustomException(ResponseStatus.DUPLICATE_REPORT);
-			});
-		UserReport userReport = UserReport.builder()
-			.reporterUuid(uuid)
-			.reportedUuid(reportedUuid)
-			.reportReason(memberReportRequestDto.getReportReason())
-			.processingResult("처리중")
-			.build();
+    //회원 신고
+    @Override
+    @Transactional
+    public void addReport(String uuid, MemberReportRequestDto memberReportRequestDto) {
+        String reportedUuid = memberReportRequestDto.getReportedUuid();
+        memberRepository.findByUuid(reportedUuid)
+            .orElseThrow(() -> new CustomException(ResponseStatus.USER_NOT_FOUND));
+        userReportRepository.findByReporterUuidAndReportedUuid(uuid, reportedUuid)
+            .ifPresent(report -> {
+                throw new CustomException(ResponseStatus.DUPLICATE_REPORT);
+            });
+        UserReport userReport = UserReport.builder()
+            .reporterUuid(uuid)
+            .reportedUuid(reportedUuid)
+            .reportReason(memberReportRequestDto.getReportReason())
+            .processingResult("처리중")
+            .build();
 
-		userReportRepository.save(userReport);
-	}
+        userReportRepository.save(userReport);
+    }
+
+    @Override
+    public void searchProfileImage(SearchForChatRoomVo searchForChatRoomVo) {
+        // 스트림을 사용하여 UUID와 프로필 이미지를 매핑하여 Map을 생성
+        Map<String, String> memberUuidsWithProfiles = searchForChatRoomVo.getMemberUuids().stream()
+            .collect(Collectors.toMap(
+                uuid -> uuid,
+                uuid -> memberRepository.findByUuid(uuid)
+                    .orElseThrow(() -> new CustomException(ResponseStatus.NO_DATA))
+                    .getProfileImage()
+            ));
+        MemberUuidsWithProfilesDto memberUuidsWithProfilesDto =
+            MemberUuidsWithProfilesDto.builder()
+                .memberUuidsWithProfiles(memberUuidsWithProfiles)
+                .auctionUuid(searchForChatRoomVo.getAuctionUuid())
+                .adminUuid(searchForChatRoomVo.getAdminUuid())
+                .title(searchForChatRoomVo.getTitle())
+                .thumbnail(searchForChatRoomVo.getThumbnail())
+                .build();
+        producer.sendMessage(Constant.SEND_TO_CHAT, memberUuidsWithProfilesDto);
+    }
+
 }

--- a/src/main/java/com/leeforgiveness/memberservice/auth/dto/MemberUuidsWithProfilesDto.java
+++ b/src/main/java/com/leeforgiveness/memberservice/auth/dto/MemberUuidsWithProfilesDto.java
@@ -1,0 +1,17 @@
+package com.leeforgiveness.memberservice.auth.dto;
+
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberUuidsWithProfilesDto {
+
+    private Map<String, String> memberUuidsWithProfiles;
+    private String auctionUuid;
+    private String title;
+    private String thumbnail;
+    private String adminUuid;
+
+}

--- a/src/main/java/com/leeforgiveness/memberservice/auth/vo/SearchForChatRoomVo.java
+++ b/src/main/java/com/leeforgiveness/memberservice/auth/vo/SearchForChatRoomVo.java
@@ -1,0 +1,29 @@
+package com.leeforgiveness.memberservice.auth.vo;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor
+@Getter
+@ToString
+public class SearchForChatRoomVo {
+
+    private String auctionUuid;
+    private List<String> memberUuids;
+    private String title;
+    private String thumbnail;
+    private String adminUuid;
+
+    @Builder
+    public SearchForChatRoomVo(String auctionUuid, List<String> memberUuids, String title,
+        String thumbnail, String adminUuid) {
+        this.auctionUuid = auctionUuid;
+        this.memberUuids = memberUuids;
+        this.title = title;
+        this.thumbnail = thumbnail;
+        this.adminUuid = adminUuid;
+    }
+}

--- a/src/main/java/com/leeforgiveness/memberservice/common/kafka/KafkaConsumerCluster.java
+++ b/src/main/java/com/leeforgiveness/memberservice/common/kafka/KafkaConsumerCluster.java
@@ -1,0 +1,39 @@
+package com.leeforgiveness.memberservice.common.kafka;
+import com.leeforgiveness.memberservice.auth.application.MemberService;
+import com.leeforgiveness.memberservice.auth.vo.SearchForChatRoomVo;
+import java.util.LinkedHashMap;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaConsumerCluster {
+
+    private final MemberService memberService;
+
+    @KafkaListener(topics = "send-to-member-for-create-chatroom-topic"
+    )
+    public void consumeBatch(@Payload LinkedHashMap<String, Object> message,
+        @Headers MessageHeaders messageHeaders) {
+        log.info("consumer: success >>> message: {}, headers: {}", message.toString(),
+            messageHeaders);
+        //message를 searchForChatRoom로 변환
+        SearchForChatRoomVo searchForChatRoomVo = SearchForChatRoomVo.builder()
+            .auctionUuid(message.get("auctionUuid").toString())
+            .memberUuids((List<String>) message.get("memberUuids"))
+            .adminUuid(message.get("adminUuid").toString())
+            .title(message.get("title").toString())
+            .thumbnail(message.get("thumbnail").toString())
+            .build();
+        log.info("auctionUuid : {}", searchForChatRoomVo.getAuctionUuid());
+        log.info("memberUuids : {}", searchForChatRoomVo.getMemberUuids());
+        memberService.searchProfileImage(searchForChatRoomVo);
+    }
+}

--- a/src/main/java/com/leeforgiveness/memberservice/common/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/leeforgiveness/memberservice/common/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,60 @@
+package com.leeforgiveness.memberservice.common.kafka;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, Object> pushEntityConsumerFactory() {
+        JsonDeserializer<Object> deserializer = gcmPushEntityJsonDeserializer();
+        return new DefaultKafkaConsumerFactory<>(
+            consumerFactoryConfig(deserializer),
+            new StringDeserializer(),
+            deserializer);
+    }
+
+    private Map<String, Object> consumerFactoryConfig(JsonDeserializer<Object> deserializer) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        return props;
+    }
+
+    private JsonDeserializer<Object> gcmPushEntityJsonDeserializer() {
+        JsonDeserializer<Object> deserializer = new JsonDeserializer<>(Object.class);
+        deserializer.setRemoveTypeHeaders(false);
+        deserializer.addTrustedPackages("*");
+        deserializer.setUseTypeMapperForKey(true);
+        return deserializer;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object>
+    kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(pushEntityConsumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/leeforgiveness/memberservice/common/kafka/KafkaProducerCluster.java
+++ b/src/main/java/com/leeforgiveness/memberservice/common/kafka/KafkaProducerCluster.java
@@ -1,0 +1,31 @@
+package com.leeforgiveness.memberservice.common.kafka;
+
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaProducerCluster {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void sendMessage(String topicName, Object object) {
+        CompletableFuture<SendResult<String, Object>> future =
+            kafkaTemplate.send(topicName, object);
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("producer: success >>> message: {}, offset: {}",
+                    result.getProducerRecord().value().toString(),
+                    result.getRecordMetadata().offset());
+            } else {
+                log.info("producer: failure >>> message: {}", ex.getMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/com/leeforgiveness/memberservice/common/kafka/KafkaProducerConfig.java
+++ b/src/main/java/com/leeforgiveness/memberservice/common/kafka/KafkaProducerConfig.java
@@ -1,0 +1,46 @@
+package com.leeforgiveness.memberservice.common.kafka;
+
+import com.leeforgiveness.memberservice.common.kafka.Topics.Constant;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaProducerConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public NewTopic chatTopic() {
+        return TopicBuilder.name(Constant.SEND_TO_CHAT)
+            .partitions(2)
+            .replicas(2)
+            .config(TopicConfig.RETENTION_MS_CONFIG, String.valueOf(86400000)) // 1일 (24시간) = 86400000 밀리초
+            .build();
+    }
+}

--- a/src/main/java/com/leeforgiveness/memberservice/common/kafka/Topics.java
+++ b/src/main/java/com/leeforgiveness/memberservice/common/kafka/Topics.java
@@ -1,0 +1,17 @@
+package com.leeforgiveness.memberservice.common.kafka;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Topics {
+    MEMBER_SERVICE(Constant.MEMBER_SERVICE),
+    SEND_TO_CHAT(Constant.SEND_TO_CHAT);
+
+    public static class Constant {
+        public static final String SEND_TO_CHAT = "send-to-chat-topic";
+        public static final String MEMBER_SERVICE = "alarm-topic";
+    }
+    private final String topic;
+}


### PR DESCRIPTION
경매글에서 멤버 서비스로 메시지를 보내 회원 프로필 이미지를 담아서 채팅으로 넘겨주는 과정입니다.

serviceImpl 전부 삭제되고 추가 한것은 Ctrl+Alt+L했다가 그렇게 된 것 같습니다.

멤버 서비스에는 카프카를 사용한 적이 없어서 기본 설정들을 추가했습니다. 